### PR TITLE
Allow to configure media type

### DIFF
--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfiguration.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfiguration.java
@@ -20,6 +20,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.With;
+import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
 
 import javax.annotation.Nullable;
@@ -70,6 +71,14 @@ public class JsonApiConfiguration {
     private final @With(AccessLevel.PRIVATE) Map<Class<?>, String> typeForClass;
 
     /**
+     * Allows to customize media type used for JSON:API payloads.
+     *
+     * @param mediaType The custom media type.
+     * @return The default is {@link MediaTypes#JSON_API}.
+     */
+    private final @With @Getter MediaType mediaType;
+
+    /**
      * Creates a mapping for a given class to get the JSON:API resource object {@literal type}
      * when rendered.
      *
@@ -108,5 +117,6 @@ public class JsonApiConfiguration {
         this.jsonApiVersionRendered = false;
         this.pageMetaAutomaticallyCreated = true;
         this.typeForClass = new LinkedHashMap<>();
+        this.mediaType = MediaTypes.JSON_API;
     }
 }

--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiMediaTypeConfiguration.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiMediaTypeConfiguration.java
@@ -40,7 +40,7 @@ class JsonApiMediaTypeConfiguration implements HypermediaMappingInformation {
     @Override
     @NonNull
     public List<MediaType> getMediaTypes() {
-        return Collections.singletonList(MediaTypes.JSON_API);
+        return Collections.singletonList(getJsonApiConfiguration().getMediaType());
     }
 
     @Override
@@ -52,7 +52,7 @@ class JsonApiMediaTypeConfiguration implements HypermediaMappingInformation {
     @NonNull
     public ObjectMapper configureObjectMapper(@NonNull ObjectMapper mapper) {
         return this.configureObjectMapper(
-                mapper, configuration.getIfAvailable(JsonApiConfiguration::new));
+                mapper, getJsonApiConfiguration());
     }
 
     @NonNull
@@ -65,5 +65,9 @@ class JsonApiMediaTypeConfiguration implements HypermediaMappingInformation {
                 configuration, beanFactory));
 
         return mapper;
+    }
+
+    private JsonApiConfiguration getJsonApiConfiguration() {
+        return configuration.getIfAvailable(JsonApiConfiguration::new);
     }
 }

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfigurationUnitTest.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfigurationUnitTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +33,7 @@ class JsonApiConfigurationUnitTest {
         assertThat(new JsonApiConfiguration().isPluralizedTypeRendered()).isTrue();
         assertThat(new JsonApiConfiguration().isJsonApiVersionRendered()).isFalse();
         assertThat(new JsonApiConfiguration().isPageMetaAutomaticallyCreated()).isTrue();
+        assertThat(new JsonApiConfiguration().getMediaType()).isEqualTo(MediaTypes.JSON_API);
     }
 
     @Test
@@ -54,5 +56,12 @@ class JsonApiConfigurationUnitTest {
     void should_set_type_for_class() {
         assertThat(new JsonApiConfiguration().withTypeForClass(Movie.class, "mymovies")
                 .getTypeForClass(Movie.class)).isEqualTo("mymovies");
+    }
+
+    @Test
+    void should_set_media_type() {
+        final MediaType mediaType = new MediaType("application", "vnd.test.api+json");
+        assertThat(new JsonApiConfiguration().withMediaType(mediaType)
+                .getMediaType()).isEqualTo(mediaType);
     }
 }


### PR DESCRIPTION
Resolves #9 

* The way the `ObjectProvider` is created in unit test is too verbose - may be should I introduce some mocking rather? If so, what is the preferred mocking library?