### PR TITLE
Add option to generate the JSON:API "type" without lower-casing

### DIFF
--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfiguration.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfiguration.java
@@ -43,6 +43,14 @@ public class JsonApiConfiguration {
     @With @Getter private final boolean pluralizedTypeRendered;
 
     /**
+     * Indicates if the JSON:API type attribute of resource objects is lower-cased.
+     *
+     * @param lowerCasedTypeRendered The new value of this configuration's lowerCasedTypeRendered
+     * @return The default is {@literal true}.
+     */
+    @With @Getter private final boolean lowerCasedTypeRendered;
+
+    /**
      * Indicates if the JSON:API version is rendered.
      * <p>
      * If set to true, each rendered JSON:API document will start with
@@ -105,6 +113,7 @@ public class JsonApiConfiguration {
      */
     public JsonApiConfiguration() {
         this.pluralizedTypeRendered = true;
+        this.lowerCasedTypeRendered = true;
         this.jsonApiVersionRendered = false;
         this.pageMetaAutomaticallyCreated = true;
         this.typeForClass = new LinkedHashMap<>();

--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiResource.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiResource.java
@@ -179,7 +179,10 @@ class JsonApiResource {
                 return new ResourceField(TYPE, type);
             }
 
-            String jsonApiType = object.getClass().getSimpleName().toLowerCase();
+            String jsonApiType = object.getClass().getSimpleName();
+            if (jsonApiConfiguration.isLowerCasedTypeRendered()) {
+                jsonApiType = jsonApiType.toLowerCase();
+            }
             if (jsonApiConfiguration.isPluralizedTypeRendered()) {
                 jsonApiType = English.plural(jsonApiType, 2);
             }

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfigurationUnitTest.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiConfigurationUnitTest.java
@@ -30,6 +30,7 @@ class JsonApiConfigurationUnitTest {
     @Test
     void should_initialize_defaults() {
         assertThat(new JsonApiConfiguration().isPluralizedTypeRendered()).isTrue();
+        assertThat(new JsonApiConfiguration().isLowerCasedTypeRendered()).isTrue();
         assertThat(new JsonApiConfiguration().isJsonApiVersionRendered()).isFalse();
         assertThat(new JsonApiConfiguration().isPageMetaAutomaticallyCreated()).isTrue();
     }
@@ -37,6 +38,11 @@ class JsonApiConfigurationUnitTest {
     @Test
     void should_set_pluralized_type() {
         assertThat(new JsonApiConfiguration().withPluralizedTypeRendered(false).isPluralizedTypeRendered()).isFalse();
+    }
+
+    @Test
+    void should_set_lower_cased_type() {
+        assertThat(new JsonApiConfiguration().withLowerCasedTypeRendered(false).isLowerCasedTypeRendered()).isFalse();
     }
 
     @Test

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiWebMvcWithConfigIntegrationTest.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiWebMvcWithConfigIntegrationTest.java
@@ -105,6 +105,7 @@ class JsonApiWebMvcWithConfigIntegrationTest extends AbstractJsonApiTest {
             return new JsonApiConfiguration()
                     .withJsonApiVersionRendered(true)
                     .withPluralizedTypeRendered(false)
+                    .withLowerCasedTypeRendered(false)
                     .withTypeForClass(MovieRepresentationModelWithoutJsonApiType.class, "my-movies");
         }
         // end::jsonApiConfig[]

--- a/lib/src/test/resources/com/toedter/spring/hateoas/jsonapi/movieEntityModelWithJsonApiVersionAndSingleType.json
+++ b/lib/src/test/resources/com/toedter/spring/hateoas/jsonapi/movieEntityModelWithJsonApiVersionAndSingleType.json
@@ -4,7 +4,7 @@
   },
   "data": {
     "id": "1",
-    "type": "movie",
+    "type": "Movie",
     "attributes": {
       "title": "Star Wars"
     }


### PR DESCRIPTION
This pull request adds an option to calculate the JSON:API `"type"` without lower-casing the class name. The generated value will be camel-cased instead of lower-cased.

The default behavior has not changed. The consumer has to explicitly activate this option in the configuration.

This option is independent of the pluralization option. So you can have, for example:

```json
{
  "id": "123",
  "type": "Movies"
}
```
OR
```json
{
  "id": "123",
  "type": "Movie"
}
```

Since this option is very similar to the pluralization option, I have followed its documentation, unit tests and integration tests exactly.