### PR TITLE
Update AbstractJsonApiModelDeserializer.java

### DIFF
--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/AbstractJsonApiModelDeserializer.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/AbstractJsonApiModelDeserializer.java
@@ -69,7 +69,8 @@ abstract class AbstractJsonApiModelDeserializer<T> extends ContainerDeserializer
         @SuppressWarnings("unchecked")
         Map<String, Object> attributes = (Map<String, Object>) data.get("attributes");
         JavaType rootType = JacksonHelper.findRootType(this.contentType);
-        final Object objectFromProperties = PropertyUtils.createObjectFromProperties(rootType.getRawClass(), attributes);
+        ObjectMapper mapper = new ObjectMapper();
+        final Object objectFromProperties = mapper.convertValue(attributes, rootType.getRawClass());    
         JsonApiResource.setJsonApiResourceFieldAttributeForObject(objectFromProperties, JsonApiResource.JsonApiResourceField.id, (String) data.get("id"));
         JsonApiResource.setJsonApiResourceFieldAttributeForObject(objectFromProperties, JsonApiResource.JsonApiResourceField.type, (String) data.get("type"));
         return objectFromProperties;


### PR DESCRIPTION
When calling `final Object objectFromProperties = PropertyUtils.createObjectFromProperties(rootType.getRawClass(), attributes);`, an exception because of a "property type mismatch" will be thrown when something like `{"x": 12}` is contained in a JSON-String, but the class has a property like `Double x;`. By using a Jackson object mapper, these errors should disappear.