### PR TITLE
Update AbstractJsonApiModelDeserializer.java

### DIFF
--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/AbstractJsonApiModelDeserializer.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/AbstractJsonApiModelDeserializer.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.springframework.hateoas.mediatype.JacksonHelper;
 import org.springframework.hateoas.mediatype.PropertyUtils;
 import org.springframework.lang.Nullable;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.*;
@@ -69,7 +70,8 @@ abstract class AbstractJsonApiModelDeserializer<T> extends ContainerDeserializer
         @SuppressWarnings("unchecked")
         Map<String, Object> attributes = (Map<String, Object>) data.get("attributes");
         JavaType rootType = JacksonHelper.findRootType(this.contentType);
-        final Object objectFromProperties = PropertyUtils.createObjectFromProperties(rootType.getRawClass(), attributes);
+        ObjectMapper mapper = new ObjectMapper();
+        final Object objectFromProperties = mapper.convertValue(attributes, rootType.getRawClass());    
         JsonApiResource.setJsonApiResourceFieldAttributeForObject(objectFromProperties, JsonApiResource.JsonApiResourceField.id, (String) data.get("id"));
         JsonApiResource.setJsonApiResourceFieldAttributeForObject(objectFromProperties, JsonApiResource.JsonApiResourceField.type, (String) data.get("type"));
         return objectFromProperties;

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/Jackson2JsonApiIntegrationTest.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/Jackson2JsonApiIntegrationTest.java
@@ -296,6 +296,19 @@ class Jackson2JsonApiIntegrationTest {
         assertThat(links.hasSingleLink()).isTrue();
         assertThat(links.getLink("self").get().getHref()).isEqualTo("http://localhost/movies/1");
     }
+    
+    @Test
+    void should_deserialize_single_movie_entity_model_with_playtime() throws Exception {
+        JavaType movieEntityModelType = mapper.getTypeFactory().constructParametricType(EntityModel.class, MovieWithPlaytime.class);
+        File file = new ClassPathResource("movieWithPlaytimeEntityModel.json", getClass()).getFile();
+        EntityModel<MovieWithPlaytime> movieEntityModel = mapper.readValue(file, movieEntityModelType);
+
+        MovieWithPlaytime movie = movieEntityModel.getContent();
+        assert movie != null;
+        assertThat(movie.getId()).isEqualTo("1");
+        assertThat(movie.getTitle()).isEqualTo("Star Wars");
+        assertThat(movie.getPlaytime()).isEqualTo(42);
+    }
 
     @Test
     void should_deserialize_single_movie_entity_model_with_one_relationship() throws Exception {

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/support/MovieWithPlaytime.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/support/MovieWithPlaytime.java
@@ -1,0 +1,16 @@
+package com.toedter.spring.hateoas.jsonapi.support;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@With
+public class MovieWithPlaytime {
+    private String id;
+    private String title;
+    private Double playtime;
+}

--- a/lib/src/test/resources/com/toedter/spring/hateoas/jsonapi/movieWithPlaytimeEntityModel.json
+++ b/lib/src/test/resources/com/toedter/spring/hateoas/jsonapi/movieWithPlaytimeEntityModel.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "1",
+    "type": "movies",
+    "attributes": {
+      "title": "Star Wars",
+      "playtime": 42
+    }
+  }
+}


### PR DESCRIPTION
When calling final Object objectFromProperties = PropertyUtils.createObjectFromProperties(rootType.getRawClass(), attributes);, an exception because of a "property type mismatch" will be thrown when something like {"x": 12} is contained in a JSON-String, but the class has a property like Double x;. By using a Jackson object mapper, these errors should disappear.
(fixed missing import)