### PR TITLE
Support ObjectMapper customization in deserializers

### DIFF
--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiCollectionModelDeserializer.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiCollectionModelDeserializer.java
@@ -18,6 +18,7 @@ package com.toedter.spring.hateoas.jsonapi;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.Links;
@@ -27,12 +28,12 @@ import java.util.List;
 class JsonApiCollectionModelDeserializer extends AbstractJsonApiModelDeserializer<CollectionModel<?>>
         implements ContextualDeserializer {
 
-    JsonApiCollectionModelDeserializer() {
-        super();
+    JsonApiCollectionModelDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper) {
+        super(jsonApiConfiguration, jsonApiMapper);
     }
 
-    protected JsonApiCollectionModelDeserializer(JavaType contentType) {
-        super(contentType);
+    protected JsonApiCollectionModelDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper, JavaType contentType) {
+        super(jsonApiConfiguration, jsonApiMapper, contentType);
     }
 
     @Override
@@ -41,7 +42,7 @@ class JsonApiCollectionModelDeserializer extends AbstractJsonApiModelDeserialize
         return CollectionModel.of(resources, links);
     }
 
-    protected JsonDeserializer<?> createJsonDeserializer(JavaType type) {
-        return new JsonApiCollectionModelDeserializer(type);
+    protected JsonDeserializer<?> createJsonDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper, JavaType type) {
+        return new JsonApiCollectionModelDeserializer(jsonApiConfiguration, jsonApiMapper, type);
     }
 }

--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiMediaTypeConfiguration.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiMediaTypeConfiguration.java
@@ -77,11 +77,6 @@ public class JsonApiMediaTypeConfiguration implements HypermediaMappingInformati
     ObjectMapper configureObjectMapper(
             @NonNull ObjectMapper mapper,
             JsonApiConfiguration configuration) {
-        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        mapper.registerModule(new Jackson2JsonApiModule());
-        mapper.setHandlerInstantiator(new JsonApiHandlerInstantiator(
-                configuration, beanFactory));
-        configuration.customize(mapper);
-        return mapper;
+        return new JsonApiHandlerInstantiator(configuration, beanFactory).configureObjectMapper(mapper);
     }
 }

--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiPagedModelDeserializer.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiPagedModelDeserializer.java
@@ -18,6 +18,7 @@ package com.toedter.spring.hateoas.jsonapi;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import org.springframework.hateoas.Links;
 import org.springframework.hateoas.PagedModel;
@@ -27,12 +28,12 @@ import java.util.List;
 class JsonApiPagedModelDeserializer extends AbstractJsonApiModelDeserializer<PagedModel<?>>
         implements ContextualDeserializer {
 
-    JsonApiPagedModelDeserializer() {
-        super();
+    JsonApiPagedModelDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper) {
+        super(jsonApiConfiguration, jsonApiMapper);
     }
 
-    protected JsonApiPagedModelDeserializer(JavaType contentType) {
-        super(contentType);
+    protected JsonApiPagedModelDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper, JavaType contentType) {
+        super(jsonApiConfiguration, jsonApiMapper, contentType);
     }
 
     @Override
@@ -42,7 +43,7 @@ class JsonApiPagedModelDeserializer extends AbstractJsonApiModelDeserializer<Pag
         return PagedModel.of(resources, null, links);
     }
 
-    protected JsonDeserializer<?> createJsonDeserializer(JavaType type) {
-        return new JsonApiPagedModelDeserializer(type);
+    protected JsonDeserializer<?> createJsonDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper, JavaType type) {
+        return new JsonApiPagedModelDeserializer(jsonApiConfiguration, jsonApiMapper, type);
     }
 }

--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiRepresentationModelDeserializer.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiRepresentationModelDeserializer.java
@@ -18,6 +18,7 @@ package com.toedter.spring.hateoas.jsonapi;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import org.springframework.hateoas.Links;
 import org.springframework.hateoas.RepresentationModel;
@@ -31,12 +32,12 @@ class JsonApiRepresentationModelDeserializer extends AbstractJsonApiModelDeseria
     public static final String CANNOT_DESERIALIZE_INPUT_TO_REPRESENTATION_MODEL
             = "Cannot deserialize input to RepresentationModel";
 
-    public JsonApiRepresentationModelDeserializer() {
-        super();
+    public JsonApiRepresentationModelDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper) {
+        super(jsonApiConfiguration, jsonApiMapper);
     }
 
-    protected JsonApiRepresentationModelDeserializer(JavaType contentType) {
-        super(contentType);
+    protected JsonApiRepresentationModelDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper, JavaType contentType) {
+        super(jsonApiConfiguration, jsonApiMapper, contentType);
     }
 
     @Override
@@ -58,7 +59,7 @@ class JsonApiRepresentationModelDeserializer extends AbstractJsonApiModelDeseria
         throw new IllegalArgumentException(CANNOT_DESERIALIZE_INPUT_TO_REPRESENTATION_MODEL);
     }
 
-    protected JsonDeserializer<?> createJsonDeserializer(JavaType type) {
-        return new JsonApiRepresentationModelDeserializer(type);
+    protected JsonDeserializer<?> createJsonDeserializer(JsonApiConfiguration jsonApiConfiguration, ObjectMapper jsonApiMapper, JavaType type) {
+        return new JsonApiRepresentationModelDeserializer(jsonApiConfiguration, jsonApiMapper, type);
     }
 }

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiEntityModelDeserializerUnitTest.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiEntityModelDeserializerUnitTest.java
@@ -16,6 +16,7 @@
 
 package com.toedter.spring.hateoas.jsonapi;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -37,7 +38,7 @@ public class JsonApiEntityModelDeserializerUnitTest {
 
     @BeforeEach
     void setUpModule() {
-        deserializer = new JsonApiEntityModelDeserializer();
+        deserializer = new JsonApiEntityModelDeserializer(new JsonApiConfiguration(), new ObjectMapper());
     }
 
     @Test

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiRepresentationModelDeserializerUnitTest.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiRepresentationModelDeserializerUnitTest.java
@@ -16,6 +16,7 @@
 
 package com.toedter.spring.hateoas.jsonapi;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -34,7 +35,7 @@ public class JsonApiRepresentationModelDeserializerUnitTest {
 
     @BeforeEach
     void setUpModule() {
-        deserializer = new JsonApiRepresentationModelDeserializer();
+        deserializer = new JsonApiRepresentationModelDeserializer(new JsonApiConfiguration(), new ObjectMapper());
     }
 
     @Test

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiWebMvcIntegrationTest.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/JsonApiWebMvcIntegrationTest.java
@@ -106,6 +106,17 @@ class JsonApiWebMvcIntegrationTest extends AbstractJsonApiTest {
     }
 
     @Test
+    void should_create_last_seen_movie() throws Exception {
+        String input = readFile("movieWithLastSeen.json");
+
+        this.mockMvc.perform(post("/movieWithLastSeen")
+                .content(input)
+                .contentType(JSON_API))
+                .andExpect(status().isCreated())
+                .andExpect(header().stringValues(HttpHeaders.LOCATION, "http://localhost/movieWithLastSeen"));
+    }
+
+    @Test
     void should_create_new_movie() throws Exception {
 
         String input = readFile("postMovie.json");

--- a/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/support/WebMvcMovieController.java
+++ b/lib/src/test/java/com/toedter/spring/hateoas/jsonapi/support/WebMvcMovieController.java
@@ -119,6 +119,11 @@ public class WebMvcMovieController {
         return EntityModel.of(movie);
     }
 
+    @PostMapping("/movieWithLastSeen")
+    public ResponseEntity<?> newLastSeenMovie(@RequestBody EntityModel<MovieWithLastSeen> movie) {
+        return ResponseEntity.created(linkTo(methodOn(getClass()).movieWithLastSeen()).toUri()).build();
+    }
+
     @PostMapping("/movies")
     public ResponseEntity<?> newMovie(@RequestBody EntityModel<Movie> movie) {
         int newMovieId = MOVIES.size() + 1;


### PR DESCRIPTION
* The main idea is to differentiate customized-only (aka plain) mapper and fully configured mapper with JsonApiModule
* JsonApiModule must be configured outside of the deserializers to prevent dependency cycle within JsonApiHandlerInstantiator