### PR TITLE
Make JsonApiModel public

### DIFF
--- a/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiModel.java
+++ b/lib/src/main/java/com/toedter/spring/hateoas/jsonapi/JsonApiModel.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class JsonApiModel extends RepresentationModel<JsonApiModel> {
+public class JsonApiModel extends RepresentationModel<JsonApiModel> {
 
     private final RepresentationModel<?> entity;
 


### PR DESCRIPTION
Hey there. We were using `JsonApiModel` in our company to implement `RepresentationModelAssembler` which takes as a generics object we want to represent as a model and representation model as a `D extends RepresentationModel<?>`. Now we are rewriting the module into reactive web flux so we implementing `ReactiveRepresentationModelAssembler` where the model is represented by `D extends RepresentationModel<D>`. This specified `D` in `RepresentationModel<D>` forces us to use some representation model instead of `?`, so we wanted to use `JsonApiModel`, but it is package-private. Is there any possibility that this model will be changed to `public`?